### PR TITLE
Fix demangling of function names with underscores

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -832,7 +832,7 @@ bool processFunction(Dwarf::Entry *entry, Cpp::Function *f)
 		f->typeOwner->classData->functions.push_back(*f);
 	}
 	else if (f->mangledName.size() > 2) {
-		int foundAt = f->mangledName.find_last_of("__");
+		int foundAt = f->mangledName.rfind("__");
 		if (foundAt != -1) {
 			char temp;
 			std::stringstream length;


### PR DESCRIPTION
`find_last_of` only matches any one character of its argument. Replaces with `rfind`, which matches the entire string. Fixes func names with more underscores e.g. `Reset__14CMenuPage50_60Fv`. Fixes crash when converting Burnout 2 July 27th prototype ELF. 